### PR TITLE
Add mise run bench task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ src/
 ### Code Quality
 
 - All checks run via `prek run -a` (defined in `prek.toml`), managed by `mise` (`mise.toml`)
+- `mise run bench` (`scripts/bench.sh`) times `check`/`format` with hyperfine over a pinned copy of the
+  Rust book cached in `target/bench/`; `check` exits 1 there, so hyperfine needs `--ignore-failure` and
+  the script asserts the expected exit codes itself. Per-rule costs are *not* measured — the 40 ms
+  process floor swamps them; that would need an in-process criterion bench
 - `prek run -a` runs hooks sequentially with `fail_fast = true`:
   trailing-whitespace → end-of-file-fixer → actionlint → hadolint → tombi check → tombi format →
   clippy (with `--fix`) → rustfmt → cargo test → mdlint check (dogfood) → mdlint format (dogfood)

--- a/README.md
+++ b/README.md
@@ -381,6 +381,13 @@ cargo build
 
 All quality checks run via `prek run -a`. This must pass before submitting a pull request.
 
+### Benchmarking
+
+`mise run bench` times `check` and `format` end to end against a pinned copy of the
+[Rust book](https://github.com/rust-lang/book) (112 Markdown files), downloading the corpus into `target/bench/` on
+first run. The numbers cover process startup, file discovery, I/O and diagnostic rendering, so they reflect the tool
+as a user experiences it rather than the cost of any single rule.
+
 ### Pull request process
 
 1. Create a feature branch from `main`

--- a/mise.lock
+++ b/mise.lock
@@ -117,6 +117,40 @@ checksum = "sha256:8e0ee174f88edb14f207a68430c7a53c2883ed509cdbde9a3a26fffa140fa
 url = "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-windows-x86_64.exe"
 url_api = "https://api.github.com/repos/hadolint/hadolint/releases/assets/295944079"
 
+[[tools.hyperfine]]
+version = "1.20.0"
+backend = "aqua:sharkdp/hyperfine"
+
+[tools.hyperfine."platforms.linux-arm64"]
+checksum = "sha256:90875cb1db7a1d797c311174d061728361e58fc70e3b62262a00635ac3b1997c"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832112"
+
+[tools.hyperfine."platforms.linux-x64"]
+checksum = "sha256:3285ec7959285288137043dd81dce0dde056227018a8277532d9a364b4f03c2b"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832008"
+
+[tools.hyperfine."platforms.linux-x64-musl"]
+checksum = "sha256:3285ec7959285288137043dd81dce0dde056227018a8277532d9a364b4f03c2b"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832008"
+
+[tools.hyperfine."platforms.macos-arm64"]
+checksum = "sha256:f58d0b90993fadfa122a351428c469ce24afef3865f027f0e6e86f0830d088f1"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832526"
+
+[tools.hyperfine."platforms.macos-x64"]
+checksum = "sha256:f58d0b90993fadfa122a351428c469ce24afef3865f027f0e6e86f0830d088f1"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832526"
+
+[tools.hyperfine."platforms.windows-x64"]
+checksum = "sha256:2508c549b049b1d4342d08edc1cb42bfac169082b6e3069431b5bab9822dbb32"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832313"
+
 [[tools.prek]]
 version = "0.4.11"
 backend = "aqua:j178/prek"

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,14 @@
 [tools]
 cargo-release = "1.1.2"
 hadolint = "2.14.0"
+hyperfine = "1.20.0"
 prek = "0.4.11"
 shellcheck = "0.11.0"
 tombi = "1.2.4"
+
+[tasks.bench]
+description = "Benchmark check and format over a pinned copy of the Rust book"
+run = "./scripts/bench.sh"
 
 [tasks.proptest]
 description = "Run formatter property tests with a large case count"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Benchmarks `mdlint check` and `mdlint format` end to end over a pinned copy of
+# the Rust book. These are whole-command numbers: they include process startup,
+# file discovery, I/O and diagnostic rendering, so they measure the tool as a
+# user experiences it rather than any one rule.
+set -euo pipefail
+
+# rust-lang/book, pinned so the corpus never shifts under the numbers.
+readonly BOOK_REV="917544888a55e4da7109bdba8c88c893c0da70f4"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache="$root/target/bench"
+pristine="$cache/pristine"
+work="$cache/work"
+binary="$root/target/release/mdlint"
+
+if [[ ! -d "$pristine" ]]; then
+  echo "fetching corpus: rust-lang/book @ ${BOOK_REV:0:12}"
+  rm -rf "$cache/book-$BOOK_REV"
+  mkdir -p "$cache"
+  curl --fail --silent --show-error --location \
+    "https://github.com/rust-lang/book/archive/$BOOK_REV.tar.gz" |
+    tar -xz -C "$cache"
+  cp -R "$cache/book-$BOOK_REV/src" "$pristine"
+  rm -rf "$cache/book-$BOOK_REV"
+fi
+
+cargo build --release
+
+echo "corpus: $(find "$pristine" -name '*.md' | wc -l | tr -d ' ') Markdown files"
+
+# `check` exits 1 on this corpus because the Rust book has violations, so
+# hyperfine has to be told to ignore exit codes. Assert them once up front
+# instead, so a binary that dies on startup fails here rather than quietly
+# benchmarking a crash.
+expect_exit() {
+  local expected="$1" label="$2" status=0
+  shift 2
+  rm -rf "$work"
+  cp -R "$pristine" "$work"
+  "$@" >/dev/null 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    echo "$label: expected exit $expected, got $status" >&2
+    exit 1
+  fi
+}
+
+expect_exit 1 "check" "$binary" check --no-fix --color never "$work"
+expect_exit 0 "format" "$binary" format --color never "$work"
+
+# `format` rewrites files and `check` does not, so every run starts from a fresh
+# copy of the corpus. The restore is setup, not measured.
+hyperfine --warmup 3 --runs 10 --ignore-failure \
+  --prepare "rm -rf '$work' && cp -R '$pristine' '$work'" \
+  --command-name "check" \
+  "$binary check --no-fix --color never '$work'" \
+  --command-name "check --parallel" \
+  "$binary check --no-fix --parallel --color never '$work'" \
+  --command-name "format" \
+  "$binary format --color never '$work'"


### PR DESCRIPTION
There was no way to see how check or format actually perform on a real-world corpus, only cargo test's pass/fail. This adds `mise run bench`, which builds a release binary and times `check` and `format` (including the `--parallel` check variant) with hyperfine over a pinned copy of the Rust book (112 Markdown files, pinned by commit so the corpus can't drift under the numbers).

scripts/bench.sh downloads that corpus into target/bench/ on first run and caches it. Since check exits 1 on the Rust book (it has real violations), hyperfine has to be told to ignore exit codes, but that would silently let a crashing binary get "benchmarked" too, so the script checks the expected exit codes itself before handing off to hyperfine.

These are whole-process numbers, not per-rule timings. They include startup, file discovery and I/O, which is fine for judging the end-user experience but not for isolating which rule is slow. That would need an in-process criterion benchmark instead, and isn't part of this change.

Also bumped prek to 0.4.11 while rebasing onto main, picking up the version main already moved to.